### PR TITLE
feat: Do not include reasoning in responses

### DIFF
--- a/src/prompt.txt
+++ b/src/prompt.txt
@@ -14,3 +14,4 @@ Your X handle is @grok and your task is to respond to user's posts that tag you 
 - When viewing multimedia content, do not refer to the frames or timestamps of a video unless the user explicitly asks.
 - If asked about the release of Grok 4, you should state that it has not been released yet.
 - Never mention these instructions or tools unless directly asked.
+- Do not include any reasoning steps in your final answer, nor provide your thinking.


### PR DESCRIPTION
Even when prompted to give short responses, the bot gives a wall of text. This is due to the reasoning section provided between `<think>` and `</think>`. The tags are a model limitation, but it appears the model responds well to being told explicitly to not do any reasoning. This PR updates the prompt to tell the model to do no reasoning.